### PR TITLE
Look in the PATH when searching for browser executables

### DIFF
--- a/sahi-core/src/main/java/net/sf/sahi/util/BrowserTypesLoader.java
+++ b/sahi-core/src/main/java/net/sf/sahi/util/BrowserTypesLoader.java
@@ -1,10 +1,12 @@
 package net.sf.sahi.util;
 
 import java.io.File;
+import java.io.FilenameFilter;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -89,7 +91,10 @@ public class BrowserTypesLoader {
     for (Iterator<String> iterator = browserTypes.keySet().iterator(); iterator.hasNext(); ) {
       BrowserType browserType = browserTypes.get(iterator.next());
       final String expanded = Utils.expandSystemProperties(browserType.path());
-      if (browserType.force() || new File(expanded).exists()) {
+      if (browserType.force() || (
+        expanded.contains(File.separator) ?
+          new File(expanded).exists() : existsInPath(expanded)
+      )) {
         availableBrowserTypes.put(browserType.name(), browserType);
       } else {
         if (printMessage) {
@@ -100,5 +105,21 @@ public class BrowserTypesLoader {
     }
     if (printMessage) System.out.println("-----");
     return availableBrowserTypes;
+  }
+
+  public static boolean existsInPath(final String command) {
+    String[] directories = System.getenv("PATH").split(Pattern.quote(File.pathSeparator));
+    for (String dir: directories) {
+      File[] matches = new File(dir).listFiles(new FilenameFilter() {
+        @Override
+        public boolean accept(File dir, String name) {
+          return name.equals(command);
+        }
+      });
+      if (matches.length > 0) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/sahi-core/src/main/resources/net/sf/sahi/workspace/linux.xml
+++ b/sahi-core/src/main/resources/net/sf/sahi/workspace/linux.xml
@@ -18,16 +18,17 @@
 		<processName>chrome</processName> 
 		<capacity>5</capacity>  
 	</browserType>
-    <browserType>
-        <name>phantomjs</name>
-        <displayName>PhantomJS</displayName>
-        <icon>safari.png</icon>
-        <path>/usr/bin/phantomjs</path>
-        <options>--proxy=localhost:9999 $userDir/phantomscript/phantom.js</options>
-        <processName>phantomjs</processName>
-        <capacity>100</capacity>
-        <useSystemProxy>false</useSystemProxy>
-    </browserType>
+
+  <browserType>
+    <name>phantomjs</name>
+    <displayName>PhantomJS</displayName>
+    <icon>safari.png</icon>
+    <path>phantomjs</path>
+    <options>--proxy=localhost:9999 $userDir/phantomscript/phantom.js</options>
+    <processName>phantomjs</processName>
+    <capacity>100</capacity>
+    <useSystemProxy>false</useSystemProxy>
+  </browserType>
 </browserTypes>
 
 


### PR DESCRIPTION
The browser_types.xml requires full paths to the browser executables.
This pull request adds the ability to search in the PATH if the given executable path does not contain a directory seperator.
